### PR TITLE
Focus dashboard on unrealized P&L, move realized summary to analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,10 +134,10 @@ All monetary fields use `Decimal` (not Float).
 
 | Route | Status | Description |
 |---|---|---|
-| `/dashboard` | **Functional** | 4 KPI cards (P&L, win rate, trades, avg return) + summary row + equity curve chart (Recharts, from portfolio snapshots) |
+| `/dashboard` | **Functional** | Unrealized-focused: 4 KPI cards (unrealized P&L / market value / cost basis per currency + open position count), per-market unrealized P&L cards (TASE in ILS with USD conversion, US in USD with ILS conversion, via `/api/exchange-rates`), equity curve chart (Recharts, from portfolio snapshots). Realized P&L summary lives on the analytics page. |
 | `/positions` | **Functional** | Open positions table with live market prices (Yahoo Finance), day change %, unrealized P&L, weight %. Refresh Prices button. Auto-refetch every 60s. Shows placeholder warning for unmapped TASE tickers. |
 | `/history` | **Functional** | Full trade table with filters (ticker/market/direction), pagination, "Show all transactions" toggle for non-trade types |
-| `/analytics` | **Functional** | Behavioral stats (8 cards), TASE vs US comparison, per-ticker P&L breakdown table, monthly P&L heatmap (color-coded grid), risk metrics cards (HHI, drawdown, Sharpe, Sortino) |
+| `/analytics` | **Functional** | Realized P&L summary (per-currency P&L, total/closed trade counts, avg return, avg holding period), behavioral stats (8 cards), TASE vs US comparison, per-ticker P&L breakdown table, monthly P&L heatmap (color-coded grid), risk metrics cards (HHI, drawdown, Sharpe, Sortino) |
 | `/import` | **Functional** | XLSX drag-and-drop import with file tracking, import status, import history table |
 | `/alerts` | Stub | Empty page |
 | `/settings` | Stub | Empty page |

--- a/apps/web/src/app/analytics/page.tsx
+++ b/apps/web/src/app/analytics/page.tsx
@@ -2,10 +2,17 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api-client";
-import { formatCurrency, formatPercent, isHebrew } from "@/lib/formatters";
+import { formatCurrency, formatNumber, formatPercent, isHebrew } from "@/lib/formatters";
+
+interface CurrencyPnl {
+  currency: string;
+  realizedPnl: number;
+  tradeCount: number;
+}
 
 interface AnalyticsSummary {
   totalRealizedPnl: number;
+  pnlByCurrency?: CurrencyPnl[];
   totalTrades: number;
   totalTradeCount: number;
   winRate: number;
@@ -90,6 +97,56 @@ export default function AnalyticsPage() {
   return (
     <div className="space-y-6">
       <h2 className="text-2xl font-bold text-gray-900">Analytics</h2>
+
+      {/* Realized P&L summary */}
+      {summary && (
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+          <div className="rounded-xl border border-gray-200 bg-white p-5">
+            <p className="text-sm text-gray-500">Total Realized P&L</p>
+            {summary.pnlByCurrency && summary.pnlByCurrency.length > 0 ? (
+              <div className="mt-1 space-y-0.5">
+                {summary.pnlByCurrency.map((p) => (
+                  <p
+                    key={p.currency}
+                    className={`text-xl font-semibold ${
+                      p.realizedPnl >= 0 ? "text-green-600" : "text-red-600"
+                    }`}
+                  >
+                    {formatCurrency(p.realizedPnl, p.currency as "ILS" | "USD")}
+                  </p>
+                ))}
+              </div>
+            ) : (
+              <p
+                className={`mt-1 text-2xl font-semibold ${
+                  summary.totalRealizedPnl >= 0
+                    ? "text-green-600"
+                    : "text-red-600"
+                }`}
+              >
+                {formatCurrency(summary.totalRealizedPnl, "USD")}
+              </p>
+            )}
+          </div>
+          <StatCard
+            label="Total Trades"
+            value={formatNumber(summary.totalTradeCount)}
+          />
+          <StatCard
+            label="Closed Trades (FIFO)"
+            value={formatNumber(summary.totalTrades)}
+          />
+          <StatCard
+            label="Avg Return"
+            value={formatPercent(summary.avgReturn)}
+            color={summary.avgReturn >= 0 ? "text-green-600" : "text-red-600"}
+          />
+          <StatCard
+            label="Avg Holding Period"
+            value={`${Math.round(summary.avgHoldingDays)} days`}
+          />
+        </div>
+      )}
 
       {/* Behavioral stats */}
       {summary && (

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api-client";
-import { formatCurrency, formatPercent, formatNumber } from "@/lib/formatters";
+import { formatCurrency, formatNumber } from "@/lib/formatters";
 import type { SyncState } from "@takumi/types";
 import {
   LineChart,
@@ -14,10 +14,17 @@ import {
   ResponsiveContainer,
 } from "recharts";
 
-interface CurrencyPnl {
-  currency: string;
-  realizedPnl: number;
-  tradeCount: number;
+type Currency = "ILS" | "USD";
+type MarketRegion = "TASE" | "US";
+
+interface OpenPosition {
+  ticker: string;
+  market: string;
+  currency: Currency;
+  totalCost: number;
+  marketValue: number;
+  unrealizedPnl: number;
+  priceSource: "live" | "cached" | "placeholder";
 }
 
 interface SnapshotData {
@@ -30,16 +37,29 @@ interface SnapshotData {
   positionCount: number;
 }
 
-interface AnalyticsSummary {
-  totalRealizedPnl: number;
-  pnlByCurrency: CurrencyPnl[];
-  totalTrades: number;
-  totalTradeCount: number;
-  winRate: number;
-  avgHoldingDays: number;
-  avgReturn: number;
-  openPositionCount: number;
-  totalOpenValue: number;
+interface ExchangeRate {
+  date: string;
+  rate: number | null;
+}
+
+interface MarketBucket {
+  region: MarketRegion;
+  currency: Currency;
+  marketValue: number;
+  totalCost: number;
+  unrealizedPnl: number;
+  positionCount: number;
+}
+
+interface CurrencyBucket {
+  marketValue: number;
+  totalCost: number;
+  unrealizedPnl: number;
+  positionCount: number;
+}
+
+function regionFor(market: string): MarketRegion {
+  return market === "TASE" ? "TASE" : "US";
 }
 
 export default function DashboardPage() {
@@ -51,9 +71,10 @@ export default function DashboardPage() {
     refetchInterval: 30_000,
   });
 
-  const { data: analytics, isLoading: analyticsLoading } = useQuery({
-    queryKey: ["analytics-summary"],
-    queryFn: () => apiFetch<AnalyticsSummary>("/api/analytics/summary"),
+  const { data: positions, isLoading: positionsLoading } = useQuery({
+    queryKey: ["positions"],
+    queryFn: () => apiFetch<OpenPosition[]>("/api/positions"),
+    refetchInterval: 60_000,
   });
 
   const { data: snapshots } = useQuery({
@@ -61,55 +82,66 @@ export default function DashboardPage() {
     queryFn: () => apiFetch<SnapshotData[]>("/api/snapshots"),
   });
 
+  const { data: fx } = useQuery({
+    queryKey: ["exchange-rate"],
+    queryFn: () => apiFetch<ExchangeRate>("/api/exchange-rates"),
+  });
+
   const captureMutation = useMutation({
     mutationFn: () => apiFetch("/api/snapshots/capture", { method: "POST" }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["snapshots"] }),
   });
 
-  const pnlDisplay = analytics?.pnlByCurrency?.length
-    ? analytics.pnlByCurrency
-        .map((p) => formatCurrency(p.realizedPnl, p.currency as "ILS" | "USD"))
-        .join("\n")
-    : analytics
-      ? formatCurrency(analytics.totalRealizedPnl, "USD")
-      : "—";
+  const rate = fx?.rate ?? null; // ILS per USD
 
-  const pnlColor =
-    analytics && analytics.totalRealizedPnl >= 0
-      ? "text-green-600"
-      : "text-red-600";
+  const convert = (value: number, from: Currency, to: Currency): number | null => {
+    if (from === to) return value;
+    if (!rate || rate <= 0) return null;
+    if (from === "USD" && to === "ILS") return value * rate;
+    if (from === "ILS" && to === "USD") return value / rate;
+    return null;
+  };
 
-  const kpis = [
-    {
-      label: "Total Realized P&L",
-      value: pnlDisplay,
-      color: pnlColor,
-      multiLine: (analytics?.pnlByCurrency?.length ?? 0) > 1,
-    },
-    {
-      label: "Win Rate",
-      value: analytics
-        ? `${analytics.winRate.toFixed(1)}%`
-        : "—",
-      color: "text-gray-900",
-      multiLine: false,
-    },
-    {
-      label: "Total Trades",
-      value: analytics ? formatNumber(analytics.totalTradeCount) : "—",
-      color: "text-gray-900",
-      multiLine: false,
-    },
-    {
-      label: "Avg Return",
-      value: analytics ? formatPercent(analytics.avgReturn) : "—",
-      color:
-        analytics && analytics.avgReturn >= 0
-          ? "text-green-600"
-          : "text-red-600",
-      multiLine: false,
-    },
-  ];
+  // Aggregate per market region and per currency
+  const byRegion = new Map<MarketRegion, MarketBucket>();
+  const byCurrency: Record<Currency, CurrencyBucket> = {
+    ILS: { marketValue: 0, totalCost: 0, unrealizedPnl: 0, positionCount: 0 },
+    USD: { marketValue: 0, totalCost: 0, unrealizedPnl: 0, positionCount: 0 },
+  };
+
+  for (const p of positions ?? []) {
+    const region = regionFor(p.market);
+    const bucket = byRegion.get(region) ?? {
+      region,
+      currency: p.currency,
+      marketValue: 0,
+      totalCost: 0,
+      unrealizedPnl: 0,
+      positionCount: 0,
+    };
+    bucket.marketValue += p.marketValue;
+    bucket.totalCost += p.totalCost;
+    bucket.unrealizedPnl += p.unrealizedPnl;
+    bucket.positionCount += 1;
+    byRegion.set(region, bucket);
+
+    byCurrency[p.currency].marketValue += p.marketValue;
+    byCurrency[p.currency].totalCost += p.totalCost;
+    byCurrency[p.currency].unrealizedPnl += p.unrealizedPnl;
+    byCurrency[p.currency].positionCount += 1;
+  }
+
+  const currencies: Currency[] = (["ILS", "USD"] as const).filter(
+    (c) => byCurrency[c].positionCount > 0
+  );
+
+  const totalPositions = positions?.length ?? 0;
+  const hasPlaceholders = positions?.some((p) => p.priceSource === "placeholder");
+
+  const regionOrder: MarketRegion[] = ["TASE", "US"];
+  const regionCards = regionOrder
+    .map((r) => byRegion.get(r))
+    .filter((b): b is MarketBucket => Boolean(b));
 
   return (
     <div className="space-y-6">
@@ -133,61 +165,129 @@ export default function DashboardPage() {
         </div>
       </div>
 
-      {/* KPI Cards */}
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-        {kpis.map((kpi) => (
-          <div
-            key={kpi.label}
-            className="rounded-xl border border-gray-200 bg-white p-5"
-          >
-            <p className="text-sm text-gray-500">{kpi.label}</p>
-            {analyticsLoading ? (
-              <span className="mt-1 inline-block h-7 w-24 animate-pulse rounded bg-gray-100" />
-            ) : kpi.multiLine && analytics?.pnlByCurrency ? (
-              <div className="mt-1 space-y-0.5">
-                {analytics.pnlByCurrency.map((p) => (
-                  <p
-                    key={p.currency}
-                    className={`text-xl font-semibold ${
-                      p.realizedPnl >= 0 ? "text-green-600" : "text-red-600"
-                    }`}
-                  >
-                    {formatCurrency(p.realizedPnl, p.currency as "ILS" | "USD")}
-                  </p>
-                ))}
-              </div>
-            ) : (
-              <p className={`mt-1 text-2xl font-semibold ${kpi.color}`}>
-                {kpi.value}
-              </p>
-            )}
-          </div>
-        ))}
-      </div>
-
-      {/* Summary cards */}
-      {analytics && (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <div className="rounded-xl border border-gray-200 bg-white p-5">
-            <p className="text-sm text-gray-500">Open Positions</p>
-            <p className="mt-1 text-xl font-semibold text-gray-900">
-              {analytics.openPositionCount}
-            </p>
-          </div>
-          <div className="rounded-xl border border-gray-200 bg-white p-5">
-            <p className="text-sm text-gray-500">Avg Holding Period</p>
-            <p className="mt-1 text-xl font-semibold text-gray-900">
-              {Math.round(analytics.avgHoldingDays)} days
-            </p>
-          </div>
-          <div className="rounded-xl border border-gray-200 bg-white p-5">
-            <p className="text-sm text-gray-500">Closed Trades (FIFO)</p>
-            <p className="mt-1 text-xl font-semibold text-gray-900">
-              {analytics.totalTrades}
-            </p>
-          </div>
+      {hasPlaceholders && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
+          Some TASE positions show placeholder prices. Unrealized P&L for those holdings reflects cost basis until live prices become available.
         </div>
       )}
+
+      {/* KPI Cards — unrealized focus */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <KpiMultiCurrencyCard
+          label="Total Unrealized P&L"
+          loading={positionsLoading}
+          currencies={currencies}
+          values={Object.fromEntries(
+            currencies.map((c) => [c, byCurrency[c].unrealizedPnl])
+          ) as Record<Currency, number>}
+          signedColor
+        />
+        <KpiMultiCurrencyCard
+          label="Total Market Value"
+          loading={positionsLoading}
+          currencies={currencies}
+          values={Object.fromEntries(
+            currencies.map((c) => [c, byCurrency[c].marketValue])
+          ) as Record<Currency, number>}
+        />
+        <KpiMultiCurrencyCard
+          label="Total Cost Basis"
+          loading={positionsLoading}
+          currencies={currencies}
+          values={Object.fromEntries(
+            currencies.map((c) => [c, byCurrency[c].totalCost])
+          ) as Record<Currency, number>}
+        />
+        <div className="rounded-xl border border-gray-200 bg-white p-5">
+          <p className="text-sm text-gray-500">Open Positions</p>
+          {positionsLoading ? (
+            <span className="mt-1 inline-block h-7 w-16 animate-pulse rounded bg-gray-100" />
+          ) : (
+            <p className="mt-1 text-2xl font-semibold text-gray-900">
+              {totalPositions}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Unrealized P&L by Market */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-lg font-semibold">Unrealized P&L by Market</h3>
+          {rate && (
+            <p className="text-xs text-gray-400">
+              FX: 1 USD = {rate.toFixed(3)} ILS
+            </p>
+          )}
+        </div>
+        {regionCards.length === 0 ? (
+          <div className="flex h-28 items-center justify-center text-gray-400">
+            No open positions.
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {regionCards.map((bucket) => {
+              const nativeCurrency = bucket.currency;
+              const otherCurrency: Currency =
+                nativeCurrency === "ILS" ? "USD" : "ILS";
+              const convertedPnl = convert(
+                bucket.unrealizedPnl,
+                nativeCurrency,
+                otherCurrency
+              );
+              const pnlPct =
+                bucket.totalCost > 0
+                  ? (bucket.unrealizedPnl / bucket.totalCost) * 100
+                  : 0;
+              const positive = bucket.unrealizedPnl >= 0;
+              return (
+                <div
+                  key={bucket.region}
+                  className="rounded-lg border border-gray-100 bg-gray-50 p-4"
+                >
+                  <div className="flex items-baseline justify-between">
+                    <p className="text-sm font-medium text-gray-600">
+                      {bucket.region === "TASE"
+                        ? "TASE (Israeli)"
+                        : "US (NYSE/NASDAQ)"}
+                    </p>
+                    <span className="text-xs text-gray-400">
+                      {bucket.positionCount} position
+                      {bucket.positionCount === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                  <p
+                    className={`mt-1 text-2xl font-bold ${
+                      positive ? "text-green-600" : "text-red-600"
+                    }`}
+                  >
+                    {formatCurrency(bucket.unrealizedPnl, nativeCurrency)}
+                  </p>
+                  <p
+                    className={`text-sm ${
+                      positive ? "text-green-600" : "text-red-600"
+                    }`}
+                  >
+                    {convertedPnl !== null
+                      ? formatCurrency(convertedPnl, otherCurrency)
+                      : `— ${otherCurrency} (no FX rate)`}
+                  </p>
+                  <div className="mt-2 flex gap-4 text-xs text-gray-500">
+                    <span>
+                      Market value:{" "}
+                      {formatCurrency(bucket.marketValue, nativeCurrency)}
+                    </span>
+                    <span>
+                      {positive ? "+" : ""}
+                      {pnlPct.toFixed(2)}%
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
 
       {/* Equity Curve */}
       <div className="rounded-xl border border-gray-200 bg-white p-6">
@@ -260,6 +360,47 @@ export default function DashboardPage() {
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+function KpiMultiCurrencyCard({
+  label,
+  loading,
+  currencies,
+  values,
+  signedColor = false,
+}: {
+  label: string;
+  loading: boolean;
+  currencies: Currency[];
+  values: Record<Currency, number>;
+  signedColor?: boolean;
+}) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5">
+      <p className="text-sm text-gray-500">{label}</p>
+      {loading ? (
+        <span className="mt-1 inline-block h-7 w-24 animate-pulse rounded bg-gray-100" />
+      ) : currencies.length === 0 ? (
+        <p className="mt-1 text-2xl font-semibold text-gray-900">—</p>
+      ) : (
+        <div className="mt-1 space-y-0.5">
+          {currencies.map((c) => {
+            const v = values[c];
+            const color = signedColor
+              ? v >= 0
+                ? "text-green-600"
+                : "text-red-600"
+              : "text-gray-900";
+            return (
+              <p key={c} className={`text-xl font-semibold ${color}`}>
+                {formatCurrency(v, c)}
+              </p>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Dashboard now leads with current-portfolio metrics: total unrealized P&L,
market value, and cost basis (per currency), plus open position count.
Adds per-market cards (TASE and US) showing unrealized P&L in both ILS
and USD using the current exchange rate from /api/exchange-rates.

Realized P&L summary (total P&L per currency, trade/closed counts, avg
return, avg holding period) moves to the top of the analytics page so
the dashboard stays focused on "what's open right now".

https://claude.ai/code/session_012Tg5ZNTrcZ5ALriDxdZZJK