### PR TITLE
perf(pnl): avoid shifting consumed FIFO lots

### DIFF
--- a/apps/api/src/services/pnl-matching.test.ts
+++ b/apps/api/src/services/pnl-matching.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { matchFifoLots, type FifoTrade } from './pnl-matching.js';
+
+const day = (offset: number) => new Date(Date.UTC(2026, 0, 1 + offset));
+
+function makeTrade(overrides: Partial<FifoTrade>): FifoTrade {
+  return {
+    ticker: 'AAPL',
+    securityName: 'Apple Inc.',
+    market: 'NASDAQ',
+    direction: 'BUY',
+    quantity: 1,
+    price: 100,
+    currency: 'USD',
+    commission: 0,
+    tradeDate: day(0),
+    ...overrides,
+  };
+}
+
+describe('matchFifoLots', () => {
+  it('handles 5,000 round trips without shifting consumed FIFO lots', () => {
+    const trades: FifoTrade[] = [];
+
+    for (let i = 0; i < 5_000; i++) {
+      trades.push(
+        makeTrade({
+          direction: 'BUY',
+          quantity: 1,
+          price: 100 + (i % 7),
+          tradeDate: day(i),
+        }),
+        makeTrade({
+          direction: 'SELL',
+          quantity: 1,
+          price: 110 + (i % 7),
+          tradeDate: day(i + 1),
+        }),
+      );
+    }
+
+    const startedAt = performance.now();
+    const result = matchFifoLots(trades);
+    const durationMs = performance.now() - startedAt;
+
+    expect(result.matchedLots).toHaveLength(5_000);
+    expect(result.openLots).toHaveLength(0);
+    expect(result.matchedLots.every((lot) => lot.realizedPnl === 10)).toBe(true);
+    expect(durationMs).toBeLessThan(250);
+  });
+
+  it('applies splits only to active open lots', () => {
+    const result = matchFifoLots([
+      makeTrade({ direction: 'BUY', quantity: 10, price: 100, tradeDate: day(0) }),
+      makeTrade({ direction: 'SELL', quantity: 10, price: 120, tradeDate: day(1) }),
+      makeTrade({ direction: 'BUY', quantity: 10, price: 50, tradeDate: day(2) }),
+      makeTrade({ direction: 'SPLIT', quantity: 10, price: 0, tradeDate: day(3) }),
+    ]);
+
+    expect(result.matchedLots).toHaveLength(1);
+    expect(result.openLots).toEqual([
+      expect.objectContaining({
+        quantity: 20,
+        price: 25,
+      }),
+    ]);
+  });
+});

--- a/apps/api/src/services/pnl-matching.ts
+++ b/apps/api/src/services/pnl-matching.ts
@@ -1,0 +1,195 @@
+/**
+ * Pure FIFO lot-matching engine.
+ *
+ * Kept separate from the Prisma-backed service so scale regressions can be
+ * tested with synthetic trade sets without a database.
+ */
+
+export interface MatchedLot {
+  ticker: string;
+  securityName: string;
+  market: string;
+  currency: string;
+  quantity: number;
+  buyPrice: number;
+  sellPrice: number;
+  buyDate: Date;
+  sellDate: Date;
+  commission: number; // combined buy + sell commission (prorated)
+  realizedPnl: number;
+  holdingDays: number;
+}
+
+export interface OpenLot {
+  ticker: string;
+  securityName: string;
+  market: string;
+  currency: string;
+  quantity: number;
+  price: number;
+  date: Date;
+  commission: number;
+}
+
+export interface FifoTrade {
+  ticker: string;
+  securityName: string;
+  market: string;
+  direction: string;
+  quantity: unknown;
+  price: unknown;
+  currency: string;
+  commission: unknown;
+  proceedsFx?: unknown;
+  proceedsIls?: unknown;
+  tradeDate: Date;
+}
+
+interface BuyLot {
+  ticker: string;
+  securityName: string;
+  market: string;
+  currency: string;
+  remainingQty: number;
+  price: number;
+  date: Date;
+  commissionPerShare: number;
+}
+
+function toNum(d: unknown): number {
+  return Number(d);
+}
+
+export function matchFifoLots(trades: FifoTrade[]): {
+  matchedLots: MatchedLot[];
+  openLots: OpenLot[];
+} {
+  // Group by ticker
+  const byTicker = new Map<string, FifoTrade[]>();
+  for (const t of trades) {
+    const existing = byTicker.get(t.ticker) || [];
+    existing.push(t);
+    byTicker.set(t.ticker, existing);
+  }
+
+  const matchedLots: MatchedLot[] = [];
+  const openLots: OpenLot[] = [];
+
+  for (const tickerTrades of byTicker.values()) {
+    const buyQueue: BuyLot[] = [];
+    let buyHead = 0;
+
+    for (const trade of tickerTrades) {
+      const qty = toNum(trade.quantity);
+      const price = toNum(trade.price);
+      const commission = toNum(trade.commission);
+
+      if (trade.direction === 'BUY') {
+        buyQueue.push({
+          ticker: trade.ticker,
+          securityName: trade.securityName,
+          market: trade.market,
+          currency: trade.currency,
+          remainingQty: qty,
+          price,
+          date: trade.tradeDate,
+          commissionPerShare: qty > 0 ? commission / qty : 0,
+        });
+      } else if (trade.direction === 'SPLIT') {
+        // IBI records bonus/split rows as bonus shares added in quantity.
+        // Distribute bonus across the currently-open lots, preserving total
+        // cost basis: multiply remainingQty by ratio, divide price & commission/share.
+        let openQty = 0;
+        for (let i = buyHead; i < buyQueue.length; i++) {
+          openQty += buyQueue[i].remainingQty;
+        }
+        if (openQty > 0 && qty !== 0) {
+          const ratio = (openQty + qty) / openQty;
+          for (let i = buyHead; i < buyQueue.length; i++) {
+            const lot = buyQueue[i];
+            lot.remainingQty *= ratio;
+            lot.price /= ratio;
+            lot.commissionPerShare /= ratio;
+          }
+        }
+      } else {
+        // SELL — match against oldest buy lots (FIFO)
+        // MAKAM / bond final-redemption rows can have execution price = 0
+        // because there is no per-share sell price on redemption; the cash is
+        // reported in proceeds. Fall back to proceeds / qty
+        // so FIFO doesn't treat the exit as $0 and manufacture a loss equal to
+        // the cost basis.
+        let effectiveSellPrice = price;
+        if (effectiveSellPrice === 0 && qty > 0) {
+          const proceeds =
+            trade.currency === 'USD'
+              ? Math.abs(toNum(trade.proceedsFx ?? 0))
+              : Math.abs(toNum(trade.proceedsIls ?? 0));
+          if (proceeds > 0) effectiveSellPrice = proceeds / qty;
+        }
+
+        let remainingToSell = qty;
+        const sellCommPerShare = qty > 0 ? commission / qty : 0;
+
+        while (remainingToSell > 0 && buyHead < buyQueue.length) {
+          const lot = buyQueue[buyHead];
+          const matchQty = Math.min(remainingToSell, lot.remainingQty);
+
+          const buyCommission = matchQty * lot.commissionPerShare;
+          const sellCommission = matchQty * sellCommPerShare;
+          const totalCommission = buyCommission + sellCommission;
+
+          const grossPnl = matchQty * (effectiveSellPrice - lot.price);
+          const realizedPnl = grossPnl - totalCommission;
+
+          const holdingDays = Math.round(
+            (trade.tradeDate.getTime() - lot.date.getTime()) / (1000 * 60 * 60 * 24)
+          );
+
+          matchedLots.push({
+            ticker: trade.ticker,
+            securityName: trade.securityName,
+            market: trade.market,
+            currency: trade.currency,
+            quantity: matchQty,
+            buyPrice: lot.price,
+            sellPrice: effectiveSellPrice,
+            buyDate: lot.date,
+            sellDate: trade.tradeDate,
+            commission: totalCommission,
+            realizedPnl,
+            holdingDays,
+          });
+
+          lot.remainingQty -= matchQty;
+          remainingToSell -= matchQty;
+
+          if (lot.remainingQty <= 0) {
+            buyHead++;
+          }
+        }
+      }
+    }
+
+    // Remaining buy lots are open positions. Start from buyHead instead of
+    // shifting consumed lots out of the queue; shifting reindexes the array on
+    // every closed lot and gets expensive as users approach thousands of trades.
+    for (let i = buyHead; i < buyQueue.length; i++) {
+      const lot = buyQueue[i];
+      if (lot.remainingQty > 0) {
+        openLots.push({
+          ticker: lot.ticker,
+          securityName: lot.securityName,
+          market: lot.market,
+          currency: lot.currency,
+          quantity: lot.remainingQty,
+          price: lot.price,
+          date: lot.date,
+          commission: lot.remainingQty * lot.commissionPerShare,
+        });
+      }
+    }
+  }
+
+  return { matchedLots, openLots };
+}

--- a/apps/api/src/services/pnl.service.ts
+++ b/apps/api/src/services/pnl.service.ts
@@ -10,32 +10,9 @@ import type { PnlWindow } from '@takumi/types';
 import { prisma } from '../lib/db.js';
 import { getCurrentRate } from './exchange-rate.service.js';
 import { logger } from '../lib/logger.js';
-
-export interface MatchedLot {
-  ticker: string;
-  securityName: string;
-  market: string;
-  currency: string;
-  quantity: number;
-  buyPrice: number;
-  sellPrice: number;
-  buyDate: Date;
-  sellDate: Date;
-  commission: number; // combined buy + sell commission (prorated)
-  realizedPnl: number;
-  holdingDays: number;
-}
-
-export interface OpenLot {
-  ticker: string;
-  securityName: string;
-  market: string;
-  currency: string;
-  quantity: number;
-  price: number;
-  date: Date;
-  commission: number;
-}
+import { matchFifoLots } from './pnl-matching.js';
+import type { MatchedLot, OpenLot } from './pnl-matching.js';
+export type { MatchedLot, OpenLot } from './pnl-matching.js';
 
 export interface TickerPnl {
   ticker: string;
@@ -50,21 +27,6 @@ export interface TickerPnl {
   avgHoldingDays: number;
   totalBuyQty: number;
   totalSellQty: number;
-}
-
-interface BuyLot {
-  ticker: string;
-  securityName: string;
-  market: string;
-  currency: string;
-  remainingQty: number;
-  price: number;
-  date: Date;
-  commissionPerShare: number;
-}
-
-function toNum(d: unknown): number {
-  return Number(d);
 }
 
 // In-memory cache for FIFO results (1-minute TTL), keyed by userId.
@@ -102,126 +64,7 @@ export async function runFifoMatching(userId: string): Promise<{
     orderBy: [{ tradeDate: 'asc' }, { createdAt: 'asc' }],
   });
 
-  // Group by ticker
-  const byTicker = new Map<string, typeof trades>();
-  for (const t of trades) {
-    const existing = byTicker.get(t.ticker) || [];
-    existing.push(t);
-    byTicker.set(t.ticker, existing);
-  }
-
-  const matchedLots: MatchedLot[] = [];
-  const openLots: OpenLot[] = [];
-
-  for (const [ticker, tickerTrades] of byTicker) {
-    const buyQueue: BuyLot[] = [];
-
-    for (const trade of tickerTrades) {
-      const qty = toNum(trade.quantity);
-      const price = toNum(trade.price);
-      const commission = toNum(trade.commission);
-
-      if (trade.direction === 'BUY') {
-        buyQueue.push({
-          ticker: trade.ticker,
-          securityName: trade.securityName,
-          market: trade.market,
-          currency: trade.currency,
-          remainingQty: qty,
-          price,
-          date: trade.tradeDate,
-          commissionPerShare: qty > 0 ? commission / qty : 0,
-        });
-      } else if (trade.direction === 'SPLIT') {
-        // IBI records splits as "הטבה" (bonus) rows: qty = bonus shares added.
-        // Distribute bonus across the currently-open lots, preserving total
-        // cost basis: multiply remainingQty by ratio, divide price & commission/share.
-        const openQty = buyQueue.reduce((s, l) => s + l.remainingQty, 0);
-        if (openQty > 0 && qty !== 0) {
-          const ratio = (openQty + qty) / openQty;
-          for (const lot of buyQueue) {
-            lot.remainingQty *= ratio;
-            lot.price /= ratio;
-            lot.commissionPerShare /= ratio;
-          }
-        }
-      } else {
-        // SELL — match against oldest buy lots (FIFO)
-        // MAKAM / bond "פדיון סופי" (final redemption) rows have שער ביצוע = 0
-        // because there is no per-share sell price on redemption — the cash is
-        // reported in תמורה בשקלים / תמורה במט"ח. Fall back to proceeds ÷ qty
-        // so FIFO doesn't treat the exit as $0 and manufacture a loss equal to
-        // the cost basis.
-        let effectiveSellPrice = price;
-        if (effectiveSellPrice === 0 && qty > 0) {
-          const proceeds =
-            trade.currency === 'USD'
-              ? Math.abs(toNum(trade.proceedsFx ?? 0))
-              : Math.abs(toNum(trade.proceedsIls ?? 0));
-          if (proceeds > 0) effectiveSellPrice = proceeds / qty;
-        }
-
-        let remainingToSell = qty;
-        const sellCommPerShare = qty > 0 ? commission / qty : 0;
-
-        while (remainingToSell > 0 && buyQueue.length > 0) {
-          const lot = buyQueue[0];
-          const matchQty = Math.min(remainingToSell, lot.remainingQty);
-
-          const buyCommission = matchQty * lot.commissionPerShare;
-          const sellCommission = matchQty * sellCommPerShare;
-          const totalCommission = buyCommission + sellCommission;
-
-          const grossPnl = matchQty * (effectiveSellPrice - lot.price);
-          const realizedPnl = grossPnl - totalCommission;
-
-          const holdingDays = Math.round(
-            (trade.tradeDate.getTime() - lot.date.getTime()) / (1000 * 60 * 60 * 24)
-          );
-
-          matchedLots.push({
-            ticker: trade.ticker,
-            securityName: trade.securityName,
-            market: trade.market,
-            currency: trade.currency,
-            quantity: matchQty,
-            buyPrice: lot.price,
-            sellPrice: effectiveSellPrice,
-            buyDate: lot.date,
-            sellDate: trade.tradeDate,
-            commission: totalCommission,
-            realizedPnl,
-            holdingDays,
-          });
-
-          lot.remainingQty -= matchQty;
-          remainingToSell -= matchQty;
-
-          if (lot.remainingQty <= 0) {
-            buyQueue.shift();
-          }
-        }
-      }
-    }
-
-    // Remaining buy lots are open positions
-    for (const lot of buyQueue) {
-      if (lot.remainingQty > 0) {
-        openLots.push({
-          ticker: lot.ticker,
-          securityName: lot.securityName,
-          market: lot.market,
-          currency: lot.currency,
-          quantity: lot.remainingQty,
-          price: lot.price,
-          date: lot.date,
-          commission: lot.remainingQty * lot.commissionPerShare,
-        });
-      }
-    }
-  }
-
-  const result = { matchedLots, openLots };
+  const result = matchFifoLots(trades);
   fifoCache.set(userId, { result, at: Date.now() });
   return result;
 }


### PR DESCRIPTION
## Summary
- extract the FIFO lot-matching loop into a pure helper so it can be scale-tested without a database
- replace `buyQueue.shift()` with a head pointer so fully consumed buy lots do not reindex the array on every matched sell
- keep split handling scoped to active open lots after the head pointer
- add a synthetic 5,000 round-trip regression for the Phase 5 scale target

## Validation
- `corepack pnpm --filter @takumi/db db:generate`
- `corepack pnpm --filter @takumi/api exec vitest run src/services/pnl-matching.test.ts` -> 2 passed, 5,000 round-trip case completed inside the 250 ms guard locally
- `corepack pnpm --filter @takumi/api exec tsc --noEmit --declaration false` -> pass
- `git diff --check` -> clean

## Baseline notes
- `corepack pnpm --filter @takumi/api build` and plain `tsc --noEmit` are currently blocked by existing TS2742 declaration-output errors on Express `app`/`router` inference outside the touched files.
- `corepack pnpm test` currently stops in Turbo with `Unable to find package manager binary: cannot find binary path` in this checkout.

Refs #21