### PR TITLE
Switch AI chat agent model to Opus 4.8

### DIFF
--- a/apps/api/src/ai/chat-handler.ts
+++ b/apps/api/src/ai/chat-handler.ts
@@ -23,7 +23,7 @@ import {
 
 const MAX_TOOL_CALLS = 10;
 const MAX_TOKENS = 4096;
-const MODEL = 'claude-sonnet-4-20250514';
+const MODEL = 'claude-opus-4-8';
 
 let anthropicClient: Anthropic | null = null;
 


### PR DESCRIPTION
Change the chat agent model from claude-sonnet-4 to claude-opus-4-8,
the most capable Opus-tier model. The streaming request already uses
no sampling/thinking params, so no other changes are required.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013TWdicp2RkBxDDCRuG7yfY